### PR TITLE
ECP-11857 RTE bug - numbers disappearing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@ build
 .env.test.local
 .env.production.local
 Thumbs.db
-
+node_modules/
 *.log

--- a/packages/language-markdown/src/markdown/MarkdownSerializer.ts
+++ b/packages/language-markdown/src/markdown/MarkdownSerializer.ts
@@ -19,7 +19,9 @@ function escape(text: string): string {
 }
 
 function cleanPositionMarkers(text: string): string {
-  return text.replace(/\n\d+\n\d+/g, "\n\n");
+  return text.replace(/\\\\\\n|((\\n|\n)\d+)+/g, (match) =>
+    match === "\\\\\\n" ? "\\\\n" : match.startsWith("\\n") ? "\\n" : "\n\n"
+  );
 }
 
 const TextToMarkdown = {


### PR DESCRIPTION
<!-- Please fill out the Whats going on here? section. -->
# ![Bug Icon](https://serenaandlily.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10503?size=medium) [ECP-11857](https://serenaandlily.atlassian.net/browse/ECP-11857) RTE bug - numbers disappearing
Parent: ![Epic Icon](https://serenaandlily.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10507?size=medium) [ECP-11584](https://serenaandlily.atlassian.net/browse/ECP-11584) September 2025 MiniQ
## Whats going on here?

_Please add a description as to what this PR does and anything to help your fellow developers to understand your implementation_

### Make sure you’re checking the [Code Review Checklist](https://serenaandlily.atlassian.net/wiki/spaces/DEV/pages/1673887773/Code+Review+Checklist) when looking into the changes.

## Description
We’re noticing that numbers are disappearing from the rich text editor in amplience when the text input starts with a number. See attached screen-recording. This is happening with all rich text editors (in product dims & care, in headlines on content pages, etc). 

* Numbers do not disappear if they are following a bullet point or any other non-numerical text. 
* Numbers disappear only if they do not follow a bullet and are set up as a “header”. 
* When you try to start a header with a number, hit save in amplience, leave the product, return to the product in amp, the numbers will have disappeared from the RTE too. 


[ECP-11857]: https://serenaandlily.atlassian.net/browse/ECP-11857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ECP-11584]: https://serenaandlily.atlassian.net/browse/ECP-11584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ